### PR TITLE
Link to General Access REST API in jupiterone.md

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -17,7 +17,11 @@
 
 ## Requirements
 
-- JupiterOne requires a PagerDuty General Access REST API key.
+- JupiterOne requires a PagerDuty
+  [General Access REST API key](https://support.pagerduty.com/docs/generating-api-keys#section-rest-api-keys).
+  **NOTE:** Pagerduty hosts two APIs - General Access REST API
+  (api.pagerduty.com) and Events API (events.pagerduty.com). JupiterOne does not
+  currently ingest data from the Events API.
 - You must have permission in JupiterOne to install new integrations.
 
 ## Support


### PR DESCRIPTION
The fact that PagerDuty has two REST API keys was confusing to some J1 users, so I've tried to clarify here.