### PR TITLE
Checking if oncallLookup exists before creating relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## Unreleased
 
+## 3.1.1 - 2022-04-11
+
+### Fixed
+
+- Adding check to on-call relationship step to prevent potential error.
+
 ## 3.1.0 - 2022-04-07
 
 ### Changed

--- a/src/steps/fetchOncalls.ts
+++ b/src/steps/fetchOncalls.ts
@@ -35,7 +35,7 @@ const step: IntegrationStep<PagerDutyIntegrationInstanceConfig> = {
         const serviceData = getRawData<Service>(serviceEntity);
         if (
           serviceData?.escalation_policy &&
-          oncallLookup[serviceData.escalation_policy.id].user?.id
+          oncallLookup[serviceData.escalation_policy.id]?.user?.id
         ) {
           await jobState.addRelationship(
             createDirectRelationship({


### PR DESCRIPTION
Small Sentry error fix.  Checking if oncallLookup exists before creating relationship.